### PR TITLE
Fix: % escape formatting fix for argparse in python >=3.14

### DIFF
--- a/watermark.py
+++ b/watermark.py
@@ -5,7 +5,7 @@ from PIL import Image, UnidentifiedImageError
 def add_watermark(directory, logo_path, position, new_directory, padding, scale):
     """
     Add a watermark to images in the specified directory.
-    
+
     Args:
     - directory (str): The directory containing images to be watermarked.
     - logo_path (str): Path to the watermark logo.
@@ -43,12 +43,12 @@ def add_watermark(directory, logo_path, position, new_directory, padding, scale)
                 except Exception as e:
                     print(f"An error occurred while processing {filename}: {e}")
                     continue
-                
+
                 full_path = os.path.join(dirpath, filename)
                 image = Image.open(full_path)
                 imageWidth, imageHeight = image.size
 
-                
+
                 shorter_side = min(imageWidth, imageHeight)
                 new_logo_width = int(shorter_side * scale/100)
                 logo_aspect_ratio = original_logo.width / original_logo.height
@@ -94,7 +94,7 @@ def add_watermark(directory, logo_path, position, new_directory, padding, scale)
                     image = image.convert('RGB')
                 image.save(new_image_path)
                 print('Added watermark to ' + new_image_path)
-                
+
     original_logo.close()
 
 
@@ -102,32 +102,32 @@ def add_watermark(directory, logo_path, position, new_directory, padding, scale)
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A script to add watermarks to images. Given a directory, this will traverse through all its images and apply the specified watermark. The resulting watermarked images can be saved in the same directory or a new specified directory, maintaining the original directory structure.")
 
-    parser.add_argument('dir', 
+    parser.add_argument('dir',
                         help="Directory containing the images you want to watermark. The script will search recursively within this directory.",
                         metavar='SourceDirectory')
 
-    parser.add_argument('logo', 
+    parser.add_argument('logo',
                         help="Path to the logo image that will be used as the watermark.",
                         metavar='WatermarkLogoPath')
 
-    parser.add_argument('--pos', 
-                        choices=['topleft', 'topright', 'bottomleft', 'bottomright', 'center'], 
+    parser.add_argument('--pos',
+                        choices=['topleft', 'topright', 'bottomleft', 'bottomright', 'center'],
                         default='center',
                         help="Specifies the position of the watermark on the image. Default is 'center'.")
 
     parser.add_argument('--new_dir',
-                        default=None, 
+                        default=None,
                         help="An optional directory where the watermarked images will be saved. If not provided, watermarked images will overwrite originals in the source directory. The original directory structure will be maintained.",
                         metavar='DestinationDirectory')
 
-    parser.add_argument('--padding', 
-                        type=int, 
+    parser.add_argument('--padding',
+                        type=int,
                         default=0,
                         help="Specifies the padding (in pixels) around the watermark, useful when watermark is positioned at the corners. Default is 0, meaning no padding.")
     parser.add_argument('--scale',
-                        type=float, 
+                        type=float,
                         default=20,
-                        help="Resize the watermark based on a percentage of the image's width. E.g., for 10% of the image's width, provide 10.")
+                        help="Resize the watermark based on a percentage of the image's width. E.g., for 10%% of the image's width, provide 10.")
 
 
     args = parser.parse_args()


### PR DESCRIPTION
As per [argparse documentation ](https://docs.python.org/3.14/library/argparse.html) as of Python 3.14: "if you want a literal % to appear in the help string, you must escape it as %%"